### PR TITLE
Added transaction design patterns.

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -3,6 +3,8 @@ project:
   output-dir: _site
   resources:
     - "*.pdf"
+    - "*.html"
+    - style/tx-patterns.css
   preview:
     port: 8000
     browser: true
@@ -31,7 +33,8 @@ format:
     theme:
       light: litera
       dark: darkly
-    css: styles.css
+    css:
+      - styles.css
     toc: true
     embed-resources: true
     link-external-icon: true

--- a/papers/1985-06-02-Tone-in-Kenyang-NPs/index.qmd
+++ b/papers/1985-06-02-Tone-in-Kenyang-NPs/index.qmd
@@ -18,7 +18,7 @@ M.A. thesis at the University of California, Los Angeles.
 PDF document: [JimTyhurst-1985-Tone-in-Kenyang-noun-phrases-MA-Thesis.pdf](./JimTyhurst-1985-Tone-in-Kenyang-noun-phrases-MA-Thesis.pdf)
 
 Indexed in:
-[OLAC Language Resource Catalog](http://www.language-archives.org/language/ken):
+[OLAC Language Resource Catalog](http://www.language-archives.org/language/ken)<br>
 at: [http://www.language-archives.org/item/oai:sil.org:9539](http://www.language-archives.org/item/oai:sil.org:9539)
 
 ## Abstract

--- a/papers/2001-10-15-transaction-design-patterns/index.qmd
+++ b/papers/2001-10-15-transaction-design-patterns/index.qmd
@@ -1,6 +1,8 @@
 ---
 title: "Choosing transaction models for enterprise applications"
-description: " "
+description: "Each design pattern for transaction models provides a solution to 
+  a problem for a given context, while considering factors that will influence
+  the choice of a solution."
 date: "2001-10-14"
 categories: [design patterns, enterprise applications]
 format: html
@@ -18,4 +20,6 @@ October 14 - 18, 2001.
 
 ## References
 
-Workshop announcement: [http://www.oopsla.org/2001/fp/workshops/23.html](http://www.oopsla.org/2001/fp/workshops/23.html)
+Browse the patterns online: [resources/tx-patterns/](../../resources/tx-patterns/)
+
+Workshop announcement: [https://www.oopsla.org/2001/fp/workshops/23.html](https://www.oopsla.org/2001/fp/workshops/23.html)

--- a/resources/tx-patterns/client/aspectChange.html
+++ b/resources/tx-patterns/client/aspectChange.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<HTML>
+<HEAD>
+  <TITLE>Aspect Change Specification</TITLE>
+  <link rel="stylesheet" href="../../../style/tx-patterns.css" type="text/css">
+</HEAD>
+<BODY>
+<H3>Aspect Change Specification</H3>
+<H4>Problem</H4>
+<P>
+  How can a client application record a change to a domain model object
+  independently from that object?
+</P>
+<H4>Context</H4>
+<P>
+  You are developing a client application and you want to record changes
+  to server objects in a
+  <A href="./txSpec.html">transaction specification</A>,
+  so that the changes can be preserved across transaction boundaries.
+  For example, you might want to
+  <A href="./replay.html">replay changes</A>
+  after aborting a transaction.
+</P>
+<H4>Forces</H4>
+<UL>
+  <LI><P>
+    <a href="../forces/noModOutsideTx.html">Objects cannot be modified outside
+      of a transaction</a>.
+  </P></LI>
+  <LI><P>
+    <a href="../forces/unitsOfWork.html">Multiple units of work</a>.
+  </P></LI>
+</UL>
+<H4>Solution</H4>
+<P>
+  Specify the message that must be sent in order to accomplish the
+  desired change. A message is completely specified by its receiver,
+  method signature, and arguments.
+</P>
+<H4>Resulting Context</H4>
+<P>
+  As a result of adopting this solution, the client application is able to
+  <A href="./replay.html">replay changes</A>
+  across transaction boundaries. Therefore after an abort, the messages can be
+  sent again, in order to redo the desired changes. This solution also supports a
+  <A href="../txModel/conversational.html">conversational</A>
+  transaction model in which the change specification is built outside of a
+  transaction and then replayed inside of a transaction to cause the changes
+  to be persistent.
+</P>
+<H4>Rationale</H4>
+<P>
+  Flexibility is achieved by maintaining an independent specification of
+  changes from the results of the changes themselves. By providing a specification,
+  rather than just recording the results, it is possible to reuse the
+  specification across transaction boundaries, so that the end user is not
+  required to reenter data.
+</P>
+<H4>Related Patterns</H4>
+<UL>
+  <LI><P>
+    <A href="./dirtyPool.html">Dirty Object Pool</A>
+    is an alternative to this <EM>Aspect Change Specification</EM> solution.
+    It is another way to record changes to domain objects, so that changes can
+    be copied into a new transaction.
+  </P></LI>
+  <LI><P>
+    <A href="../conflict/lastWins.html">Last Commit Wins</A>
+    and
+    <A href="../conflict/mergeUpdates.html">Merge Conflicting Updates</A>
+    provide specific strategies for replaying changes.
+  </P></LI>
+</UL>
+</BODY>
+</HTML>

--- a/resources/tx-patterns/client/checkout.html
+++ b/resources/tx-patterns/client/checkout.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<HTML>
+<HEAD>
+  <TITLE>Check Out Objects</TITLE>
+  <link rel="stylesheet" href="../../../style/tx-patterns.css" type="text/css">
+</HEAD>
+<BODY>
+<H3>Check Out Objects</H3>
+<H4>Problem</H4>
+<P>
+  How can you maintain a lock on an object for a long period of time?
+</P>
+<H4>Context</H4>
+<P>
+  You are developing a multi-user application that commits
+  transactions on an application server. In your application, there is a
+  substantial risk of a commit failure due to the probability of two clients
+  modifying the same object during overlapping time intervals and you need to
+  lock objects for an extended period of time.
+</P>
+<H4>Forces</H4>
+<UL>
+  <LI><P>
+    <a href="../forces/length.html">Length of transaction</a>.
+  </P></LI>
+  <LI><P>
+    <a href="../forces/noModOutsideTx.html">Objects cannot be modified outside of a transaction</a>.
+  </P></LI>
+</UL>
+<H4>Solution</H4>
+<P>
+  Develop a lock table that holds persistent locks for objects that
+  have been checked out. The application checks out a copy of the
+  object, makes changes, and then checks in the changed copy.
+</P>
+<H4>Resulting Context</H4>
+<P>
+  Since the application is making changes outside of a transaction, it will
+  need to
+  <A href="./replay.html">replay the changes</A>
+  within a server transaction. Also, the application must implement the lock table,
+  which has its own concurrency issues.
+</P>
+<H4>Rationale</H4>
+<P>
+  Application servers typically provide a locking mechanism within transactions.
+  However, if updates need to be made during a long period of time,
+  it is unreasonable to keep a transaction open
+  while the changes are made. For example, if changes are made by an end user
+  through a user interface, it is advisable for the changes to be specified
+  outside of a transaction. In this case, the application must implement
+  its own locking mechanism that will work across transactions.
+</P>
+<H4>Related Patterns</H4>
+<P>
+  <A href="./replay.html">Replay Changes</A>
+  solves some of the problems in the resulting context set up by this pattern.
+</P>
+</BODY>
+</HTML>

--- a/resources/tx-patterns/client/dirtyPool.html
+++ b/resources/tx-patterns/client/dirtyPool.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<HTML>
+<HEAD>
+  <TITLE>Dirty Object Pool</TITLE>
+  <link rel="stylesheet" href="../../../style/tx-patterns.css" type="text/css">
+</HEAD>
+<BODY>
+<H3>Dirty Object Pool</H3>
+<H4>Problem</H4>
+<P>
+  How can a client application record a change to a domain model object
+  independently from that object?
+</P>
+<H4>Context</H4>
+<P>
+  You are developing a client application and you want to record changes
+  to server objects in a
+  <A href="./txSpec.html">transaction specification</A>,
+  so that the changes can be preserved across transaction boundaries.
+  For example, you might want to
+  <A href="./replay.html">replay changes</A>
+  after aborting a transaction.
+</P>
+<H4>Forces</H4>
+<UL>
+  <LI><P>
+    <a href="../forces/noModOutsideTx.html">Objects cannot be modified outside
+      of a transaction</a>.
+  </P></LI>
+  <LI><P>
+    <a href="../forces/unitsOfWork.html">Multiple units of work</a>.
+  </P></LI>
+</UL>
+<H4>Solution</H4>
+<P>
+  Keep a copy of the object in its changed state, where the copy is local to
+  the client and is unaffected by transaction boundaries in the application
+  server.
+</P>
+<H4>Resulting Context</H4>
+<P>
+  As a result of adopting this solution, the client application is able to
+  <A href="./replay.html">replay changes</A>
+  across transaction boundaries. Therefore after an abort, data from the non-persistent
+  copies of domain objects can be copied into persistent domain objects
+  within a transaction,
+  in order to redo the desired changes. This solution also supports a
+  <A href="../txModel/conversational.html">conversational</A>
+  transaction model in which the change specification is built outside of a
+  transaction and then replayed inside of a transaction to cause the changes
+  to be persistent.
+</P>
+<H4>Rationale</H4>
+<P>
+  There are several advantages to this solution:
+</P>
+<OL>
+  <LI><P>
+    Changes to persistent objects can be made outside of a server transaction,
+    which allows you to implement long business transactions with short
+    server transactions.
+  </P></LI>
+  <LI><P>
+    You do not lose a user's changes when a commit failure occurs.
+  </P></LI>
+</OL>
+<P>
+  Compared to the
+  <A href="./aspectChange.html">Aspect Change Specification</A>
+  pattern, this solution requires quite a bit of overhead, because copies
+  of the persistent object graph must be maintained in non-persistent
+  objects outside of the view of the repository. It is easy to maintain
+  a copy of a single object, but for an entire graph, the references between
+  objects must also be maintained.
+</P>
+<H4>Related Patterns</H4>
+<UL>
+  <LI><P>
+    <A href="./aspectChange.html">Aspect Change Specification</A>
+    is an alternative to this <EM>Dirty Object Pool</EM> solution.
+    It is another way to record a specification of changes to domain objects,
+    so that changes can be replayed in a new transaction.
+  </P></LI>
+  <LI><P>
+    <A href="../conflict/lastWins.html">Last Commit Wins</A>
+    and
+    <A href="../conflict/mergeUpdates.html">Merge Conflicting Updates</A>
+    provide specific strategies for replaying changes.
+  </P></LI>
+</UL>
+</BODY>
+</HTML>

--- a/resources/tx-patterns/client/index.html
+++ b/resources/tx-patterns/client/index.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<html>
+<head>
+  <title>Defining transactions in a client application</title>
+  <link rel="stylesheet" href="../../../style/tx-patterns.css" type="text/css">
+</head>
+<body>
+<h2>Defining transactions in a client application</h2>
+<table>
+  <tr>
+    <th>Pattern Name</th>
+    <th>Problem</th>
+    <th>Solution</th>
+  </tr>
+  <tr>
+    <td>
+      <a href="./replay.html">Replay Changes</a>
+    </td>
+    <td>
+      How can a client application preserve a user's changes after aborting
+      a transaction?
+    </td>
+    <td>
+      The client keeps the changes independent from the view of the repository,
+      so that when a view is refreshed, the changes may be replayed.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="./txSpec.html">Transaction Specification</a>
+    </td>
+    <td>
+      How can changes to domain model objects be saved independently from
+      the domain model?
+    </td>
+    <td>
+      Save the sequence of messages that can be sent to cause the desired
+      changes to occur.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="./aspectChange.html">Aspect Change Specification</a>
+    </td>
+    <td>
+      How can a client application record a change to a domain model object
+      independently from that object?
+    </td>
+    <td>
+      Specify the message that must be sent in order to accomplish the
+      desired change. A message is completely specified by its receiver,
+      method signature, and arguments.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="./dirtyPool.html">Dirty Object Pool</a>
+    </td>
+    <td>
+      How can a client application record a change to a domain model object
+      independently from that object?
+    </td>
+    <td>
+      Keep a copy of the object in its changed state.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <A href="./lock.html">Locked Object</A>
+    </td>
+    <td>
+      How can you reduce the risk of a commit failure when modifying
+      an object?
+    </td>
+    <td>
+      Obtain a write lock on an object before modifying it.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <A href="./checkout.html">Check Out Objects</A>
+    </td>
+    <td>
+      How can you maintain a lock on an object for a long period of time?
+    </td>
+    <td>
+      Develop a lock table that holds persistent locks for objects that
+      have been checked out. The application checks out a copy of the
+      object, makes changes, and then checks in the changed copy.
+    </td>
+  </tr>
+</table>
+</body>
+</html>

--- a/resources/tx-patterns/client/lock.html
+++ b/resources/tx-patterns/client/lock.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<HTML>
+<HEAD>
+  <TITLE>Locked Object</TITLE>
+  <link rel="stylesheet" href="../../../style/tx-patterns.css" type="text/css">
+</HEAD>
+<BODY>
+<H3>Locked Object</H3>
+<H4>Problem</H4>
+<P>
+  How can you reduce the risk of a commit failure when modifying
+  an object?
+</P>
+<H4>Context</H4>
+<P>
+  You are developing a multi-user application that commits
+  transactions on an application server. In your application, there is a
+  substantial risk of a commit failure due to the probability of two clients
+  modifying the same object during overlapping time intervals.
+</P>
+<H4>Forces</H4>
+<UL>
+  <LI><P>
+    <a href="../forces/commitFailure.html">Failure to commit</a>.
+  </P></LI>
+  <LI><P>
+    <a href="../forces/writeConflict.html">Write-Write conflicts</a>.
+  </P></LI>
+  <LI><P>
+    <a href="../forces/conflictProbability.html">Probability of a commit failure</a>.
+  </P></LI>
+  <LI><P>
+    <a href="../forces/length.html">Length of transaction</a>.
+  </P></LI>
+</UL>
+<H4>Solution</H4>
+<P>
+  Obtain a write lock on an object before modifying it.
+</P>
+<H4>Resulting Context</H4>
+<P>
+  You need to design your locking strategy carefully when obtaining multiple
+  locks, so as not to lead to a
+  deadlock situation where two separate processes are each waiting for a lock
+  held by the other.
+</P>
+<H4>Rationale</H4>
+<P>
+  This solution reduces the
+  <A href="../forces/conflictProbability.html">probability of commit failure</A>
+  by assuring that the locking process is the only client to be making updates
+  to an object.
+</P>
+<H4>Related Patterns</H4>
+<UL>
+  <LI><P>
+    <A href="./checkout.html">Check Out Objects</A>
+    provides a way to "lock" an object for a long period of time, so that the
+    lock may be maintained across transactions and outside of transactions
+    for an indefinite amount of time.
+  </P></LI>
+  <LI><P>
+    <A href="./replay.html">Replay Changes</A>
+    can be used when the
+    <A href="../forces/conflictProbability.html">probability of commit failure</A>
+    is relatively low.
+  </P></LI>
+</UL>
+</BODY>
+</HTML>

--- a/resources/tx-patterns/client/replay.html
+++ b/resources/tx-patterns/client/replay.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<HTML>
+<HEAD>
+  <TITLE>Replay Changes</TITLE>
+  <link rel="stylesheet" href="../../../style/tx-patterns.css" type="text/css">
+</HEAD>
+<BODY>
+<H3>Replay Changes</H3>
+<H4>Problem</H4>
+<P>
+  How can a client application preserve a user's changes after aborting
+  a transaction?
+</P>
+<H4>Context</H4>
+<P>
+  You are developing a multi-user application that commits
+  transactions on an application server. There are several reasons why you might
+  want to be able to replay a user's business transaction after aborting
+  a server transaction:
+</P>
+<UL>
+  <LI><P>
+    If a transaction fails, you need to abort the transaction to get a clean view
+    of the repository. However, rather than losing the user's changes, you would
+    like to be able to attempt the transaction again.
+  </P></LI>
+  <LI><P>
+    For long business transactions, it may be desirable to change persistent
+    objects while outside of a server transaction. However, changes to persistent
+    objects can only be saved in the repository while in a transaction.
+    Therefore, you might want to allow the user to modify an object outside
+    of a transaction, then replay the changes inside of a transaction.
+  </P></LI>
+</UL>
+<H4>Forces</H4>
+<UL>
+  <LI><P>
+    <a href="../forces/commitFailure.html">Failure to commit</a>.
+  </P></LI>
+  <LI><P>
+    <a href="../forces/writeConflict.html">Write-Write conflicts</a>.
+  </P></LI>
+  <LI><P>
+    <a href="../forces/conflictProbability.html">Probability of a commit failure</a>.
+  </P></LI>
+  <LI><P>
+    <a href="../forces/length.html">Length of transaction</a>.
+  </P></LI>
+  <LI><P>
+    <a href="../forces/dataCurrency.html">Data currency</a>.
+  </P></LI>
+  <LI><P>
+    <a href="../forces/noModOutsideTx.html">Objects cannot be modified outside of a transaction</a>.
+  </P></LI>
+  <LI><P>
+    <a href="../forces/sigAbort.html">Signal to abort</a>.
+  </P></LI>
+  <LI><P>
+    <a href="../forces/unitsOfWork.html">Multiple units of work</a>.
+  </P></LI>
+</UL>
+<H4>Solution</H4>
+<P>
+  The client keeps the changes independent from the view of the repository,
+  so that when a view is refreshed, the changes may be replayed.
+</P>
+<H4>Resulting Context</H4>
+<P>
+  In order to be able to replay changes, you need to be able to identify
+  the changes that were made as part of the current business transaction,
+  as explained in the
+  <A href="./txSpec.html">Transaction Specification</A>
+  pattern.
+</P>
+<P>
+  Two different strategies for replaying changes are described in:
+</P>
+<UL>
+  <LI><P>
+    <A href="../conflict/lastWins.html">Last Commit Wins</A>
+  </P></LI>
+  <LI><P>
+    <A href="../conflict/mergeUpdates.html">Merge Conflicting Updates</A>
+  </P></LI>
+</UL>
+<H4>Rationale</H4>
+<P>
+  There are two benefits to this solution:
+</P>
+<OL>
+  <LI><P>
+    Changes to persistent objects can be made outside of a server transaction,
+    which allows you to implement long business transactions with short
+    server transactions.
+  </P></LI>
+  <LI><P>
+    You do not lose a user's changes when a commit failure occurs.
+  </P></LI>
+</OL>
+<H4>Related Patterns</H4>
+<UL>
+  <LI><P>
+    <A href="./txSpec.html">Transaction Specification</A>
+    provides a record of changes, so that they can be replayed.
+  </P></LI>
+  <LI><P>
+    <A href="./aspectChange.html">Aspect Change Specification</A>
+    is a way to record user-initiated changes to domain objects which must
+    be replayed.
+  </P></LI>
+  <LI><P>
+    <A href="./dirtyPool.html">Dirty Object Pool</A>
+    is another way to record changes to domain objects, so that the changes
+    can be copied into a new transaction.
+  </P></LI>
+  <LI><P>
+    <A href="../conflict/lastWins.html">Last Commit Wins</A>
+    and
+    <A href="../conflict/mergeUpdates.html">Merge Conflicting Updates</A>
+    provide specific strategies for replaying changes.
+  </P></LI>
+</UL>
+</BODY>
+</HTML>

--- a/resources/tx-patterns/client/txSpec.html
+++ b/resources/tx-patterns/client/txSpec.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<HTML>
+<HEAD>
+  <TITLE>Transaction Specification</TITLE>
+  <link rel="stylesheet" href="../../../style/tx-patterns.css" type="text/css">
+</HEAD>
+<BODY>
+<H3>Transaction Specification</H3>
+<H4>Problem</H4>
+<P>
+  How can changes to domain model objects be saved independently from
+  the domain model?
+</P>
+<H4>Context</H4>
+<P>
+  You are developing a multi-user application that commits
+  transactions on an application server. There are several reasons why you might
+  want to be able to replay a user's business transaction after aborting
+  a server transaction:
+</P>
+<UL>
+  <LI><P>
+    If a transaction fails, you need to abort the transaction to get a clean view
+    of the repository. However, rather than losing the user's changes, you would
+    like to be able to attempt the transaction again.
+  </P></LI>
+  <LI><P>
+    For long business transactions, it may be desirable to change persistent
+    objects while outside of a server transaction. However, changes to persistent
+    objects can only be saved in the repository while in a transaction.
+    Therefore, you might want to allow the user to modify an object outside
+    of a transaction, then replay the changes inside of a transaction.
+  </P></LI>
+  <H4>Forces</H4>
+  <UL>
+    <LI><P>
+      <a href="../forces/commitFailure.html">Failure to commit</a>.
+    </P></LI>
+    <LI><P>
+      <a href="../forces/writeConflict.html">Write-Write conflict</a>.
+    </P></LI>
+    <LI><P>
+      <a href="../forces/noModOutsideTx.html">Objects cannot be modified outside
+        of a transaction</a>.
+    </P></LI>
+  </UL>
+  <H4>Solution</H4>
+  <P>
+    Save the sequence of messages that can be sent to cause the desired
+    changes to occur.
+  </P>
+  <P>
+    A transaction specification represents a sequence of changes to server
+    objects. These change specifications are maintained independent of the
+    target objects, so that the changes can be preserved after the
+    application server aborts a transaction, rolling back the view
+    of the repository to a previous state. The changes can then be
+    replayed in a new transaction.
+  </P>
+  <H4>Resulting Context</H4>
+  <P>
+    As a result of adopting this solution, the developer must decide how to keep
+    a record of changes in a business transaction.
+    <A href="./aspectChange.html">Aspect Change Specification</A>
+    records the sequence of messages that must be sent in order to cause the
+    desired changes. After an abort, the messages can be sent again,
+    in order to redo the desired changes.
+  </P>
+  <H4>Rationale</H4>
+  <P>
+    This solution is relatively easy to implement, although it requires explicit
+    code in the client application to record the messages sent to domain objects.
+  </P>
+  <P>
+    The solution does not involve any copying. Therefore, it does not introduce
+    a large number of extra temporary objects into the environment. It also
+    means that references between objects are maintained with no extra effort.
+  </P>
+  <P>
+    By recording the sequence of messages, business rules that are triggered
+    by setter methods will reapply in the correct sequence whenever the
+    transaction is replayed.
+  </P>
+  <H4>Related Patterns</H4>
+  <UL>
+    <LI><P>
+      <A href="./aspectChange.html">Aspect Change Specification</A>
+      is a way to record user-initiated changes to domain objects which
+      may be replayed.
+    </P></LI>
+    <LI><P>
+      <A href="./dirtyPool.html">Dirty Object Pool</A>
+      is an alternative to this <EM>Transaction Specification</EM> solution.
+      It is another way to record changes to domain objects, so that changes can
+      be copied into a new transaction.
+    </P></LI>
+    <LI><P>
+      <A href="../conflict/lastWins.html">Last Commit Wins</A>
+      and
+      <A href="../conflict/mergeUpdates.html">Merge Conflicting Updates</A>
+      provide specific strategies for replaying changes.
+    </P></LI>
+  </UL>
+</BODY>
+</HTML>

--- a/resources/tx-patterns/conflict/firstWins.html
+++ b/resources/tx-patterns/conflict/firstWins.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<HTML>
+<HEAD>
+  <TITLE>First Commit Wins</TITLE>
+  <link rel="stylesheet" href="../../../style/tx-patterns.css" type="text/css">
+</HEAD>
+<BODY>
+<H3>First Commit Wins</H3>
+<H4>Problem</H4>
+<P>
+  How can you serialize a set of changes from overlapping business
+  transactions that affect the same object when your primary concern
+  is for users to see changes immediately as they occur?
+</P>
+<H4>Context</H4>
+<P>
+  You are developing a multi-user application that
+  commits transactions on an application server.
+  Two or more transactions may overlap while trying to update the same
+  object. It is essential that users are aware of each other's
+  changes to busines objects.
+</P>
+<H4>Forces</H4>
+<UL>
+  <LI><P>
+    <a href="../forces/commitFailure.html">Failure to commit</a>.
+  </P></LI>
+  <LI><P>
+    <a href="../forces/writeConflict.html">Write-Write conflict</a>.
+  </P></LI>
+  <LI><P>
+    <a href="../forces/conflictProbability.html">Probability of a commit failure</a>.
+  </P></LI>
+  <LI><P>
+    <a href="../forces/dataCurrency.html">Data currency</a>.
+  </P></LI>
+</UL>
+<H4>Solution</H4>
+<P>
+  A transactional application server allows the first server transaction
+  to "win" in the sense that successive transactions having a
+  <A href="../forces/writeConflict.html">write-write conflict</A>
+  will fail. Whenever a client application experiences a commit failure,
+  abort the transaction, and refresh the user's view from the current state
+  of the server. This will cause the user to lose all of their changes,
+  forcing them to start a new business transaction.
+  They will need to reevaluate the new data manually in order to decide whether
+  to redo their changes or not.
+</P>
+<H4>Resulting Context</H4>
+<P>
+  Changes from other transactions can only be introduced at transaction
+  boundaries, so the amount of work affected by updating a view will depend
+  on the
+  <A href="../txModel/index.html">transaction model</A>
+  that has been chosen.
+</P>
+<P>
+  Since there is no attempt to preserve the user's changes that cause the
+  conflict, it is not necessary to
+  <A href="../client/index.html">represent the user's changes</A>
+  independently of the view.
+</P>
+<H4>Rationale</H4>
+<P>
+  This is a very easy pattern to implement. While it sounds terrible to cause the
+  end user to redo their work, this may be acceptable when the
+  <A href="../forces/conflictProbability.html">probability of a commit failure</A>
+  is so low that it can be ignored.
+</P>
+<H4>Related Patterns</H4>
+<UL>
+  <LI><P>
+    <A href="./mergeUpdates.html">Merge Conflicting Updates</A>
+    provides a different solution to this problem by allowing the replay
+    of changes in the last transaction to selectively update the conflicting object.
+  </P></LI>
+  <LI><P>
+    <A href="./lastWins.html">Last Commit Wins</A>
+    provides a different solution to this problem by initiating a new server
+    transaction automatically and replaying the user's changes, which
+    may overwrite some of the changes from the first committed transaction.
+  </P></LI>
+</UL>
+</BODY>
+</HTML>

--- a/resources/tx-patterns/conflict/index.html
+++ b/resources/tx-patterns/conflict/index.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html>
+<head>
+  <title>Resolving conflicts between transactions</title>
+  <link rel="stylesheet" href="../../../style/tx-patterns.css" type="text/css">
+</head>
+<body>
+<h2>Resolving conflicts between transactions</h2>
+<table>
+  <tr>
+    <th>Pattern Name</th>
+    <th>Problem</th>
+    <th>Solution</th>
+  </tr>
+  <tr>
+    <td>
+      <a href="./firstWins.html">First Commit Wins</a>
+    </td>
+    <td>
+      How can you serialize a set of changes from overlapping business
+      transactions that affect the same object when your primary concern
+      is for users to see changes immediately as they occur?
+    </td>
+    <td>
+      Force the user to start a new business transaction starting from the
+      latest server state whenever the user's changes cause a commit failure
+      in a server transaction.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="./mergeUpdates.html">Merge Conflicting Updates</a>
+    </td>
+    <td>
+      How can you serialize a set of changes from overlapping business
+      transactions that affect the same object when your primary concern
+      is that users should not have to reenter any data?
+    </td>
+    <td>
+      Selectively replay the user's changes in a new server transaction,
+      prompting the user whenever there are conflicts at the individual
+      aspect level of the object.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="./lastWins.html">Last Commit Wins</a>
+    </td>
+    <td>
+      How can you serialize a set of changes from overlapping business
+      transactions that affect the same object when your primary concern
+      is that users should not have to reenter any data and the probability
+      of conflict is relatively small?
+    </td>
+    <td>
+      Replay all of the changes in a new transaction, overwriting previously
+      committed changes if necessary.
+    </td>
+  </tr>
+</table>
+</body>
+</html>

--- a/resources/tx-patterns/conflict/lastWins.html
+++ b/resources/tx-patterns/conflict/lastWins.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<HTML>
+<HEAD>
+  <TITLE>Last Commit Wins</TITLE>
+  <link rel="stylesheet" href="../../../style/tx-patterns.css" type="text/css">
+</HEAD>
+<BODY>
+<H3>Last Commit Wins</H3>
+<H4>Problem</H4>
+<P>
+  How can you serialize a set of changes from overlapping business
+  transactions that affect the same object?
+</P>
+<H4>Context</H4>
+<P>
+  You are developing a multi-user application that
+  commits transactions on an application server.
+  Two or more transactions may overlap while trying to update the same
+  object.
+</P>
+<H4>Forces</H4>
+<UL>
+  <LI><P>
+    <a href="../forces/commitFailure.html">Failure to commit</a>.
+  </P></LI>
+  <LI><P>
+    <a href="../forces/writeConflict.html">Write-Write conflict</a>.
+  </P></LI>
+  <LI><P>
+    <a href="../forces/conflictProbability.html">Probability of a commit failure</a>.
+  </P></LI>
+  <LI><P>
+    <a href="../forces/dataCurrency.html">Data currency</a>.
+  </P></LI>
+</UL>
+<H4>Solution</H4>
+<P>
+  A transactional application server allows the first server transaction
+  to "win" in the sense that successive transactions having a
+  <A href="../forces/writeConflict.html">write-write conflict</A>
+  will fail.
+  However, it is possible for the second client to abort the failed transaction,
+  begin a new transaction,
+  <A href="../client/replay.html">replay the changes</A>,
+  and commit the new transaction.
+</P>
+<H4>Resulting Context</H4>
+<P>
+  In order to provide the ability to replay changes, there must
+  be a way to define
+  <A href="../client/index.html">transaction specifications</A>
+  in the client.
+</P>
+<H4>Rationale</H4>
+<P>
+  This is an easy pattern to implement, as long as there is a way to define
+  <A href="../client/index.html">transaction specifications</A>
+  in the client. At first glance, this solution appears to violate the
+  objectives of a transactional system, since the second transaction may
+  overwrite the effects of the first transaction. However, as long as
+  appropriate business rules validate changes as they are played back,
+  there is no risk of changing the repository into an inconsistent state.
+</P>
+<P>
+  One of the disadvantages of this solution is that the software automatically
+  resolves the conflict without notifying the end user that a conflict occurred.
+  In situations where such notification is important or manual merging of
+  changes is more appropriate, then the
+  <A href="./firstWins.html">First Commit Wins</A>
+  or the
+  <A href="./mergeUpdates.html">Merge Conflicting Updates</A>
+  patterns are more appropriate.
+</P>
+<P>
+  The disadvantages of this solution may be acceptable when the
+  <A href="../forces/conflictProbability.html">probability of a commit failure</A>
+  is so low that it can be ignored or where commit failures typically do not
+  have business consequences. For example, suppose a customer service organization
+  changes addresses and other customer contact information, while a billing
+  organization updates a customer's purchasing information. It is possible that
+  the application server may report a conflict between a customer service
+  transaction and a billing transaction, while from a business perspective the two
+  transactions are updating different aspects of the customer object.
+</P>
+<H4>Related Patterns</H4>
+<UL>
+  <LI><P>
+    <A href="./firstWins.html">First Commit Wins</A>
+    provides a different solution to this problem by forcing the user
+    to start a new business transaction, starting from the updated object
+    that results from the first committed transaction.
+  </P></LI>
+  <LI><P>
+    <A href="./mergeUpdates.html">Merge Conflicting Updates</A>
+    provides a different solution to this problem by allowing the replay
+    of changes in the last transaction to selectively update the conflicting object.
+  </P></LI>
+</UL>
+</BODY>
+</HTML>

--- a/resources/tx-patterns/conflict/mergeUpdates.html
+++ b/resources/tx-patterns/conflict/mergeUpdates.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<HTML>
+<HEAD>
+<TITLE>Merge Conflicting Updates</TITLE>
+<LINK rel="stylesheet" href="../../../../style/default.css" type="text/css"> 
+</HEAD>
+<BODY>
+<CENTER>
+<a href="./index.html">Resolving conflicts between transactions</a>
+</CENTER>
+<HR>
+<H3>Merge Conflicting Updates</H3> 
+<H4>Problem</H4>
+<P>
+How can you serialize a set of changes from overlapping business
+transactions that affect the same object when your primary concern
+is that users should not have to reenter any data?
+</P>
+<H4>Context</H4>
+<P>
+You are developing a multi-user application that
+commits transactions on an application server.
+Two or more transactions may overlap while trying to update the same
+object.
+</P>
+<H4>Forces</H4>
+<UL>
+<LI><P>
+<a href="../forces/commitFailure.html">Failure to commit</a>.
+</P></LI>
+<LI><P>
+<a href="../forces/writeConflict.html">Write-Write conflict</a>.
+</P></LI>
+<LI><P>
+<a href="../forces/conflictProbability.html">Probability of a commit failure</a>.
+</P></LI>
+<LI><P>
+<a href="../forces/dataCurrency.html">Data currency</a>.
+</P></LI>
+</UL>
+<H4>Solution</H4>
+<P>
+A transactional application server allows the first server transaction
+to "win" in the sense that successive transactions having a
+<A href="../forces/writeConflict.html">write-write conflict</A> 
+will fail.
+However, it is possible for the second client to abort the failed transaction,
+begin a new transaction, 
+<A href="../client/replay.html">replay the changes</A>,
+and commit the new transaction.  While replaying the changes, you must
+check each individual change to determine whether there is a conflict
+with the first committed transaction.  If so, prompt the user to determine
+whether or not the new change should be applied.
+</P>
+<H4>Resulting Context</H4>
+<P>
+Changes from other transactions can only be introduced at transaction
+boundaries, so the amount of work affected by updating a view will depend
+on the 
+<A href="../txModel/index.html">transaction model</A>
+that has been chosen.
+</P>
+<P>
+In order to provide the ability to replay changes, there must 
+be a way to define 
+<A href="../client/index.html">transaction specifications</A> 
+in the client.
+</P>
+<H4>Rationale</H4>
+<P>
+This solution identifies the server transaction conflict to the user,
+enabling the user to make the necessary adjustments to merge the two sets
+of changes appropriately.  It minimizes the amount of rework that the
+end user must do, in order to complete their business transaction.
+</P>
+<H4>Related Patterns</H4>
+<UL>
+<LI><P>
+<A href="./firstWins.html">First Commit Wins</A> 
+provides a different solution to this problem by forcing the user
+to start a new business transaction, starting from the updated object
+that results from the first committed transaction.
+</P></LI>
+<LI><P>
+<A href="./lastWins.html">Last Commit Wins</A> 
+provides a different solution to this problem by initiating a new server
+transaction automatically and replaying the user's changes, which
+may overwrite some of the changes from the first committed transaction.
+</P></LI>
+</UL>
+<HR>
+<CENTER>
+<a href="./index.html">Resolving conflicts between transactions</a>
+</CENTER>
+</BODY>
+</HTML>

--- a/resources/tx-patterns/forces/commitFailure.html
+++ b/resources/tx-patterns/forces/commitFailure.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<HTML>
+<HEAD>
+  <TITLE>Failure to commit</TITLE>
+  <link rel="stylesheet" href="../../../style/tx-patterns.css" type="text/css">
+</HEAD>
+<BODY>
+<H3>Failure to commit</H3>
+<P>
+  When trying to commit a transaction, the commit operation may fail due
+  to conflicts with transactions from other clients. In some application
+  servers, a transaction that has failed will never succeed in the future.
+  Therefore, the client must abort (or <EM>roll back</EM>) the failed transaction
+  and start a new transaction with the desired changes. Either the
+  application must provide the ability to replay the changes automatically
+  or the user will have to re-enter the data manually.
+</P>
+</BODY>
+</HTML>

--- a/resources/tx-patterns/forces/conflictProbability.html
+++ b/resources/tx-patterns/forces/conflictProbability.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<HTML>
+<HEAD>
+  <TITLE>Probability of a commit failure</TITLE>
+  <link rel="stylesheet" href="../../../style/tx-patterns.css" type="text/css">
+</HEAD>
+<BODY>
+<H3>Probability of a commit failure</H3>
+<P>
+  Your motivation to design and implement a solution for a
+  <A href="./commitFailure.html">failure to commit</A>
+  depends on the probability of a failure occurring in your particular
+  application. If the likelihood of a
+  <A href="./writeConflict.html">write-write conflict</A>
+  is very very small, then it may be acceptable to simply display an error
+  message to the user, abort the transaction, and force the user to
+  begin the business transaction again.
+  On the other hand, when losing the user's changes is an unacceptable
+  solution, especially when it may occur relatively frequently, you
+  will want to provide a solution to recover from a
+  <A href="./commitFailure.html">failure to commit</A>.
+</P>
+</BODY>
+</HTML>

--- a/resources/tx-patterns/forces/dataCurrency.html
+++ b/resources/tx-patterns/forces/dataCurrency.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<HTML>
+<HEAD>
+<TITLE>Data currency</TITLE>
+  <link rel="stylesheet" href="../../../style/tx-patterns.css" type="text/css">
+</HEAD>
+<BODY>
+<H3>Data currency</H3>
+<P>
+The views displayed to a particular user must be updated as the domain
+model changes on the server (see patterns 
+<A href="../view/push.html">Push Model Changes</A>
+and 
+<A href="../view/pull.html">Pull Model Changes</A>). 
+However, these changes may only be integrated into the user's view
+at transaction boundaries.
+</P>
+</BODY>
+</HTML>

--- a/resources/tx-patterns/forces/index.html
+++ b/resources/tx-patterns/forces/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<HTML>
+<HEAD>
+  <TITLE>Forces that influence design decisions</TITLE>
+  <link rel="stylesheet" href="../../../style/tx-patterns.css" type="text/css">
+</HEAD>
+<BODY>
+<H2>Forces that influence design decisions regarding transaction models</H2>
+<UL>
+  <LI><a href="./commitFailure.html">Failure to commit</a>.</LI>
+  <LI><a href="./writeConflict.html">Write-Write conflicts</a>.</LI>
+  <LI><a href="./conflictProbability.html">Probability of a commit failure</a>.</LI>
+  <LI><a href="./length.html">Length of transaction</a>.</LI>
+  <LI><a href="./dataCurrency.html">Data currency</a>.</LI>
+  <LI><a href="./noModOutsideTx.html">Objects cannot be modified outside of a transaction</a>.</LI>
+  <LI><a href="./sigAbort.html">Server forcing application to abort</a>.</LI>
+  <LI><a href="./txMode.html">Transaction modes</a>.</LI>
+  <LI><a href="./unitsOfWork.html">Multiple units of work</a>.</LI>
+</UL>
+</BODY>
+</HTML>

--- a/resources/tx-patterns/forces/length.html
+++ b/resources/tx-patterns/forces/length.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<HTML>
+<HEAD>
+  <TITLE>Length of a transaction</TITLE>
+  <link rel="stylesheet" href="../../../style/tx-patterns.css" type="text/css">
+</HEAD>
+<BODY>
+<H3>Length of a transaction</H3>
+<P>
+  There are several problems associated with long transactions:
+<UL>
+  <LI><P>
+    If locks are held, resources are tied up for the length of the transaction,
+    which limits the ability of multiple users to access the data.
+  </P></LI>
+  <LI><P>
+    If locks are not used, the risk of a
+    <A href="./commitFailure.html">commit failure</A>
+    increases with the length of the transaction, because there is
+    a greater time period in which other users might commit a transaction
+    that would cause a
+    <A href="./writeConflict.html">conflict</A>.
+  </P></LI>
+  <LI><P>
+    The architectures of most application servers encourage short transactions,
+    because performance problems can occur when there is a large backlog
+    open transactions competing for resources.
+  </P></LI>
+</UL>
+</P>
+</BODY>
+</HTML>

--- a/resources/tx-patterns/forces/noModOutsideTx.html
+++ b/resources/tx-patterns/forces/noModOutsideTx.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<HTML>
+<HEAD>
+  <TITLE>Objects cannot be modified outside of a transaction</TITLE>
+  <link rel="stylesheet" href="../../../style/tx-patterns.css" type="text/css">
+</HEAD>
+<BODY>
+<H3>Objects cannot be modified outside of a transaction</H3>
+<P>
+  Changes made to persistent objects while outside of a transaction
+  cannot be committed. In order to change persistent objects,
+  the application must begin a new transaction, make changes to the
+  objects, and then commit the transaction.
+</P>
+</BODY>
+</HTML>

--- a/resources/tx-patterns/forces/sigAbort.html
+++ b/resources/tx-patterns/forces/sigAbort.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<HTML>
+<HEAD>
+  <TITLE>Signal to abort</TITLE>
+  <link rel="stylesheet" href="../../../style/tx-patterns.css" type="text/css">
+</HEAD>
+<BODY>
+<H3>Signal to abort</H3>
+<P>
+  When the client is working outside of a transaction while maintaining
+  a session on an application server, the server may
+  signal the client to abort (i.e. refresh its view of the repository).
+  In response, the client should abort, in order to refresh the current
+  view. This allows the application server to reclaim obsolete objects.
+</P>
+</BODY>
+</HTML>

--- a/resources/tx-patterns/forces/txMode.html
+++ b/resources/tx-patterns/forces/txMode.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<HTML>
+<HEAD>
+  <TITLE>Transaction modes</TITLE>
+  <link rel="stylesheet" href="../../../style/tx-patterns.css" type="text/css">
+</HEAD>
+<BODY>
+<H3>Transaction modes</H3>
+<P>
+  Application servers may provide several modes for beginning transactions,
+  including:
+</P>
+<DL>
+  <DT><P>
+    Manual transaction mode
+  <DD>
+    You explicitly control when your session begins a transaction. When you
+    commit or abort a transaction, you will again be outside of a transaction.
+    Changes to existing objects or new objects created while outside of a
+    transaction will not be persistent.
+  </DD>
+  </P></DT>
+  <DT><P>
+    Automatic transaction mode
+  <DD>
+    When the client establishes a session with the application server, it is
+    immediately put into a transaction and a new transaction is started
+    automatically after each commit or abort action.
+  </DD>
+  </P></DT>
+</DL>
+</BODY>
+</HTML>

--- a/resources/tx-patterns/forces/unitsOfWork.html
+++ b/resources/tx-patterns/forces/unitsOfWork.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<HTML>
+<HEAD>
+  <TITLE>Multiple units of work</TITLE>
+  <link rel="stylesheet" href="../../../style/tx-patterns.css" type="text/css">
+</HEAD>
+<BODY>
+<H3>Multiple units of work</H3>
+<P>
+  When mapping business transactions to server transactions,
+  the application designer needs to determine each unit
+  of work that must be recorded as a consistent whole. Dependencies
+  between these units of work will influence the choice
+  <A href="../txModel/index.html">transaction models</A>.
+</P>
+</BODY>
+</HTML>

--- a/resources/tx-patterns/forces/writeConflict.html
+++ b/resources/tx-patterns/forces/writeConflict.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<HTML>
+<HEAD>
+  <TITLE>Write-Write conflicts</TITLE>
+  <link rel="stylesheet" href="../../../style/tx-patterns.css" type="text/css">
+</HEAD>
+<BODY>
+<H3>Write-Write conflicts</H3>
+<P>
+  When you try to commit your transaction, the commit may fail as a result
+  of conflicts with other transactions. A write-write conflict occurs when
+  an object in your write set is also in the write set of a transaction
+  that has been commited since your transaction began.
+</P>
+</BODY>
+</HTML>

--- a/resources/tx-patterns/index.html
+++ b/resources/tx-patterns/index.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html>
+<head>
+  <title>Transaction Model Patterns</title>
+  <link rel="stylesheet" href="../../style/tx-patterns.css" type="text/css">
+</head>
+<body>
+<h1>Transaction Model Patterns</h1>
+<p>
+  Jim Tyhurst.
+  <br>
+  "Choosing transaction models for enterprise applications".
+  <br>
+  Presented at the
+  "<a href="http://www.oopsla.org/2001/fp/workshops/23.html">Three-Tier Architecture Pattern Language</a>"
+  workshop at the Association for Computing Machinery's
+  <a href="http://www.oopsla.org/2001/">Conference on Object-Oriented Programming,
+    Systems, Languages, and Applications (OOPSLA 2001)</a>.
+  <br>
+  Tampa, FL. Oct. 14 - 18, 2001.
+</p>
+<ul>
+  <li><p>
+    <a href="./txModel/index.html">Selecting a transaction model</a>.
+  </p></li>
+  <li><p>
+    <a href="./client/index.html">Defining transactions in a client application</a>.
+  </p></li>
+  <li><p>
+    <a href="./conflict/index.html">Resolving conflicts between transactions</a>.
+  </p></li>
+  <li><p>
+    <a href="./view/index.html">Updating views at transaction boundaries</a>.
+  </p></li>
+  <li><p>
+    <a href="./forces/index.html">Forces that influence design decisions regarding transaction
+      models</a>.
+  </p></li>
+</ul>
+</body>
+</html>

--- a/resources/tx-patterns/txModel/chained.html
+++ b/resources/tx-patterns/txModel/chained.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html>
+<head>
+  <title>Chained Transaction</title>
+  <link rel="stylesheet" href="../../../style/tx-patterns.css" type="text/css">
+</head>
+<body>
+<h3>Chained Transaction</h3>
+<h4>Problem</h4>
+<p>
+  How can a client application organize a set of domain model changes
+  to be submitted in a series of transactions while holding locks across
+  transaction boundaries?
+</p>
+<h4>Context</h4>
+<p>
+  You are developing a client application that commits a series of transactions on an
+  application server for a single business transaction. An object
+  is to be updated in more than one of these transactions.
+</p>
+<h4>Forces</h4>
+<ul>
+  <li><p>
+    <a href="../forces/writeConflict.html">Write-write conflict</a>.
+  </p></li>
+  <li><p>
+    <a href="../forces/length.html">Length of transaction</a>.
+  </p></li>
+</ul>
+<h4>Solution</h4>
+<p>
+  Commit the work of a
+  <a href="./flat.html">Flat Transaction</a>
+  and then remain in a transaction, while holding previous locks.
+</p>
+<h4>Resulting Context</h4>
+<p>
+  Each transaction in the chain is treated as a
+  <a href="./flat.html">Flat Transaction</a>.
+  However, this solution has the added complexity that you need to
+  specify the scope for obtaining and releasing a
+  <a href="../client/lock.html">write lock</a>.
+</p>
+<h4>Rationale</h4>
+<p>
+  This model provides a way increase the probability of being able to
+  commit a series of changes to an object, even if those changes are
+  performed in separate transactions.
+</p>
+<h4>Related Patterns</h4>
+<p>
+  For other solutions to this same problem, see the list of patterns for
+  <a href="./index.html">selecting a transaction model</a>.
+</p>
+</body>
+</html>

--- a/resources/tx-patterns/txModel/conversational.html
+++ b/resources/tx-patterns/txModel/conversational.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html>
+<head>
+  <title>Conversational Transaction</title>
+  <link rel="stylesheet" href="../../../style/tx-patterns.css" type="text/css">
+</head>
+<body>
+<h3>Conversational Transaction</h3>
+<h4>Problem</h4>
+<p>
+  How can a client application organize a set of domain model changes
+  to be submitted in a transaction where the user needs a relatively
+  long time to specify the changes, but the server prefers short
+  transactions?
+</p>
+<h4>Context</h4>
+<p>
+  You are developing a user interface for a multi-user application that
+  commits transactions on an application server. People using the system
+  perform business transactions that typically take a few minutes,
+  but which may remain open for an arbitrarily long time (e.g. the user
+  opens a customer screen and then goes to lunch before saving the data
+  that has been entered).
+</p>
+<h4>Forces</h4>
+<ul>
+  <li><p>
+    <a href="../forces/length.html">Length of transaction</a>.
+  </p></li>
+  <li><p>
+    <a href="../forces/noModOutsideTx.html">Objects cannot be modified outside
+      of a transaction</a>.
+  </p></li>
+  <li><p>
+    <a href="../forces/sigAbort.html">Signal to abort</a>.
+  </p></li>
+  <li><p>
+    <a href="../forces/txMode.html">Transaction modes supported by the application server</a>.
+  </p></li>
+  <li><p>
+    <a href="../forces/commitFailure.html">Failure to commit</a>.
+  </p></li>
+</ul>
+<h4>Solution</h4>
+<p>
+  Let the user perform the business transaction outside of a server transaction.
+  At the completion of the business transaction, open a server transaction,
+  apply the accumulated changes, and commit the transaction.
+  The client performs the following steps:
+</p>
+<ol>
+  <li>Begin a transaction, read some data, and abort the transaction.</li>
+  <li>Process the data outside of a transaction.</li>
+  <li>Begin a transaction, apply the updates, and commit the transaction.</li>
+</ol>
+<h4>Resulting Context</h4>
+<p>
+  In order to apply this pattern, one must have a way of saving changes that
+  are made outside of a transaction, so that they can be reapplied inside of
+  a transaction. The
+  <a href="../client/replay.html">Replay Changes</a>
+  pattern provides a solution to this problem.
+</p>
+<p>
+  For long business transactions where objects must be locked for an extended period
+  of time, the
+  <a href="../client/checkOut.html">Check Out Objects</a>
+  pattern provides a way to lock objects while minimizing the use of server
+  resources.
+</p>
+<h4>Rationale</h4>
+<p>
+  One of the advantages of this solution is that it provides a way to handle long
+  business transactions with a server that prefers short transactions.
+  By using short server transactions, the application reduces the resource
+  requirements placed on the server, resulting in better performance.
+</p>
+<h4>Related Patterns</h4>
+<ul>
+  <li><p>
+    For other solutions to this same problem, see the list of patterns for
+    <a href="./index.html">selecting a transaction model</a>.
+  </p></li>
+  <li><p>
+    <a href="../client/replay.html">Replay Changes</a>
+    provides a way of saving
+    changes that are made outside of a transaction, so that they can be
+    reapplied inside of a transaction.
+  </p></li>
+  <li><p>
+    <a href="../client/checkOut.html">Check Out Objects</a>
+    provides a way to lock
+    objects for an extended period of time while minimizing the use of server
+    resources.
+  </p></li>
+</ul>
+</body>
+</html>

--- a/resources/tx-patterns/txModel/flat.html
+++ b/resources/tx-patterns/txModel/flat.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html>
+<head>
+  <title>Flat Transaction</title>
+  <link rel="stylesheet" href="../../../style/tx-patterns.css" type="text/css">
+</head>
+<body>
+<h3>Flat Transaction</h3>
+<h4>Problem</h4>
+<p>
+  How can a client application organize a set of domain model changes to be
+  submitted in a transaction that is easy to implement?
+</p>
+<h4>Context</h4>
+<p>
+  You are developing a client application that commits transactions on an
+  application server.
+</p>
+<h4>Forces</h4>
+<ul>
+  <li><p>
+    <a href="../forces/length.html">Length of transaction</a>.
+  </p></li>
+  <li><p>
+    <a href="../forces/txMode.html">Transaction modes supported by the application server</a>.
+  </p></li>
+</ul>
+<h4>Solution</h4>
+<p>
+  Group all of the changes in a single transaction that has no internal structure.
+  Use the application server's
+  <a href="../forces/txMode.html">manual transaction mode</a>
+  to open a server transaction at the beginning of the business transaction,
+  make the desired changes, and then commit the server transaction at the
+  end of the business transaction.
+</p>
+<h4>Resulting Context</h4>
+<p>
+  In order to reduce the risk of commit failures, you may want to obtain a
+  <a href="../client/lock.html">write lock</a>
+  for objects that you are changing.
+</p>
+<p>
+  If the client application includes a user interface to a person, you need to
+  consider the consequences of having relatively long transactions. Other models,
+  such as
+  <a href="./conversational.html">Conversational Transactions</a>,
+  provide a way to limit the use of system resources for long business transactions.
+</p>
+<h4>Rationale</h4>
+<p>
+  This is an easy model to implement, because it assumes that the business
+  transaction can be directly implemented as a server transaction. This model
+  is well understood by developers, as it is commonly used for relational databases.
+</p>
+<h4>Related Patterns</h4>
+<p>
+  For other solutions to this same problem, see the list of patterns for
+  <a href="./index.html">selecting a transaction model</a>.
+</p>
+<h4>Variants</h4>
+<p>
+  <a href="../client/lock.html">Locking</a> objects at the beginning of the
+  transaction is a common way to assure that the commit will be
+  successful.
+</p>
+</body>
+</html>

--- a/resources/tx-patterns/txModel/index.html
+++ b/resources/tx-patterns/txModel/index.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html>
+<head>
+  <title>Selecting a transaction model</title>
+  <link rel="stylesheet" href="../../../style/tx-patterns.css" type="text/css">
+</head>
+<body>
+<h2>Selecting a transaction model</h2>
+<table>
+  <tr>
+    <th>Pattern Name</th>
+    <th>Problem</th>
+    <th>Solution</th>
+  </tr>
+  <tr>
+    <td>
+      <a href="./flat.html">Flat Transaction</a>
+    </td>
+    <td>
+      How can a client application organize a set of domain model changes to be
+      submitted in a transaction that is easy to implement?
+    </td>
+    <td>
+      Group all of the changes in a single transaction that has no internal structure.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="./chained.html">Chained Transaction</a>
+    </td>
+    <td>
+      How can a client application organize a set of domain model changes
+      to be submitted in a series of transactions while holding locks across
+      transaction boundaries?
+    </td>
+    <td>
+      Commit the work of a
+      Flat Transaction
+      and then remain in a transaction, while holding previous locks.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="./conversational.html">Conversational Transaction</a>
+    </td>
+    <td>
+      How can a client application organize a set of domain model changes
+      to be submitted in a transaction where the user needs a relatively
+      long time to specify the changes, but the server prefers short
+      transactions?
+    </td>
+    <td>
+      Perform one transaction to read data, process the data offline,
+      and then submit the changes in a new transaction.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      Queued Transaction
+    </td>
+    <td>
+      How can a client application organize a set of domain model changes
+      to be submitted in a transaction where there are many clients
+      adding new independent data?
+    </td>
+    <td>
+      Specify the actions to be performed in a transaction and submit
+      that specification into the queue of a transaction processor.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      Nested Transaction
+    </td>
+    <td>
+      How can a client application organize a set of domain model changes
+      to be submitted in a transaction where the changes are organized
+      in hierarchical increments?
+    </td>
+    <td>
+      Provide a nested structure of transactions, so that each
+      embedded transaction can be rolled back without affecting higher
+      level transactions.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      Distributed Transaction
+    </td>
+    <td>
+      How can a client application organize a set of domain model changes
+      to be submitted in a transaction where the domain model
+      is distributed across more than one server?
+    </td>
+    <td>
+      Provide a two-phase commit process, where each server verifies
+      that it can commit its portion of the transaction before any
+      server performs its portion of the commit.
+    </td>
+  </tr>
+</table>
+</body>
+</html>

--- a/resources/tx-patterns/txModel/queued.html
+++ b/resources/tx-patterns/txModel/queued.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html>
+<head>
+  <title>Queued Transaction</title>
+  <link rel="stylesheet" href="../../../style/tx-patterns.css" type="text/css">
+</head>
+<body>
+<h3>Queued Transaction</h3>
+<h4>Problem</h4>
+<p>
+  How can a client application organize a set of domain model changes
+  to be submitted in a transaction where there are many clients
+  adding new independent data?
+</p>
+<h4>Context</h4>
+<p>
+  tbd
+</p>
+<h4>Forces</h4>
+<ul>
+  <li><p>
+    <a href="../forces/length.html">Length of transaction</a>.
+  </p></li>
+  <li><p>
+    <a href="../forces/noModOutsideTx.html">Objects cannot be modified outside of a transaction</a>.
+  </p></li>
+  <li><p>
+    <a href="../forces/sigAbort.html">Signal to abort</a>.
+  </p></li>
+  <li><p>
+    <a href="../forces/txMode.html">Transaction modes supported by the application server</a>.
+  </p></li>
+  <li><p>
+    <a href="../forces/commitFailure.html">Failure to commit</a>.
+  </p></li>
+</ul>
+<h4>Solution</h4>
+<p>
+  Specify the actions to be performed in a transaction and submit
+  that specification into the queue of a transaction processor.
+</p>
+<h4>Resulting Context</h4>
+<p>
+  tbd
+</p>
+<h4>Rationale</h4>
+<p>
+  tbd
+</p>
+<h4>Related Patterns</h4>
+<p>
+  For other solutions to this same problem, see the list of patterns for
+  <a href="./index.html">selecting a transaction model</a>.
+</p>
+</body>
+</html>

--- a/resources/tx-patterns/view/index.html
+++ b/resources/tx-patterns/view/index.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html>
+<head>
+  <title>Updating views at transaction boundaries</title>
+  <link rel="stylesheet" href="../../../style/tx-patterns.css" type="text/css">
+</head>
+<body>
+<h2>Updating views at transaction boundaries</h2>
+<table>
+  <tr>
+    <th>Pattern Name</th>
+    <th>Problem</th>
+    <th>Solution</th>
+  </tr>
+  <tr>
+    <td>
+      <a href="./push.html">Push Domain Model Changes</a>
+    </td>
+    <td>
+      When one user commits a transaction that updates the domain model
+      on the server, how can a client application display these changes
+      to a different user?
+    </td>
+    <td>
+      The client registers as an observer of specific model components
+      and the server notifies observers when changes occur.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="./pull.html">Pull Domain Model Changes</a>
+    </td>
+    <td>
+      When one user commits a transaction that updates the domain model
+      on the server, how can a client application display these changes
+      to a different user?
+    </td>
+    <td>
+      The client aborts its transaction periodically, in order to
+      refresh its view of the repository.
+    </td>
+  </tr>
+</table>
+</body>
+</html>

--- a/resources/tx-patterns/view/pull.html
+++ b/resources/tx-patterns/view/pull.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<HTML>
+<HEAD>
+  <TITLE>Pull Domain Model Changes</TITLE>
+  <link rel="stylesheet" href="../../../style/tx-patterns.css" type="text/css">
+</HEAD>
+<BODY>
+<H3>Pull Domain Model Changes</H3>
+<H4>Problem</H4>
+<P>
+  When one user commits a transaction that updates the domain model
+  on the server, how can a client application display these changes
+  to a different user?
+</P>
+<H4>Context</H4>
+<P>
+  You are developing a multi-user application that
+  commits transactions on an application server. Changes to persistent
+  data should be propagated to everyone viewing the data.
+</P>
+<H4>Forces</H4>
+<UL>
+  <LI><P>
+    <a href="../forces/dataCurrency.html">Data currency</a>.
+  </P></LI>
+</UL>
+<H4>Solution</H4>
+<P>
+  The client aborts its transaction periodically, in order to
+  refresh its view of the repository.
+</P>
+<H4>Resulting Context</H4>
+<P>
+  Changes from other transactions can only be introduced at transaction
+  boundaries, so the client developer needs to consider when it is appropriate
+  to refresh its view based on the
+  <A href="../txModel/index.html">transaction model</A>
+  that has been chosen.
+</P>
+<P>
+  Updating a view could overwrite changes that are in progress by the
+  end user. Therefore, it may be necessary to
+  <A href="../client/index.html">represent the user's changes</A>
+  independently of the view.
+</P>
+<H4>Rationale</H4>
+<P>
+  An advantage of this solution is that it puts the client in control of when
+  to receive updates of shared persistent data. The client explicitly checks
+  for updates whenever it is willing to update its view.
+  In contrast to
+  <A href="./push.html">pushing domain model changes</A>,
+  there is no wasted processing time when the client is not interested
+  in updating its view.
+</P>
+<P>
+  A disadvantage is that the client may waste time and resources polling for
+  changes when none have occurred. If updating a view is expensive, e.g. on a slow
+  network, the client may experience unnecessary delays when there are no
+  changes to the components in which it is interested.
+</P>
+<H4>Related Patterns</H4>
+<UL>
+  <LI><P>
+    <A href="./push.html">Push Domain Model Changes</A>.
+  </P></LI>
+</UL>
+</BODY>
+</HTML>

--- a/resources/tx-patterns/view/push.html
+++ b/resources/tx-patterns/view/push.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<HTML>
+<HEAD>
+  <TITLE>Push Domain Model Changes</TITLE>
+  <link rel="stylesheet" href="../../../style/tx-patterns.css" type="text/css">
+</HEAD>
+<BODY>
+<H3>Push Domain Model Changes</H3>
+<H4>Problem</H4>
+<P>
+  When one user commits a transaction that updates the domain model
+  on the server, how can a client application display these changes
+  to a different user?
+</P>
+<H4>Context</H4>
+<P>
+  You are developing a multi-user application that
+  commits transactions on an application server. Changes to persistent
+  data should be propagated to everyone viewing the data.
+</P>
+<H4>Forces</H4>
+<UL>
+  <LI><P>
+    <a href="../forces/dataCurrency.html">Data currency</a>.
+  </P></LI>
+</UL>
+<H4>Solution</H4>
+<P>
+  The client registers as an observer of specific model components
+  and the server notifies observers when changes occur.
+</P>
+<H4>Resulting Context</H4>
+<P>
+  Changes from other transactions can only be introduced at transaction
+  boundaries, so the client developer needs to consider when it is appropriate
+  to refresh its view based on the
+  <A href="../txModel/index.html">transaction model</A>
+  that has been chosen.
+</P>
+<P>
+  Updating a view could overwrite changes that are in progress by the
+  end user. Therefore, it may be necessary to
+  <A href="../client/index.html">represent the user's changes</A>
+  independently of the view.
+</P>
+<H4>Rationale</H4>
+<P>
+  Registering as an observer makes it easy for the client to identify
+  when its view needs to be updated, because it receives a notification
+  everytime this is necessary. In contrast to
+  <A href="./pull.html">pulling domain model changes</A>,
+  there is no wasted processing time when no view updates are necessary.
+</P>
+<P>
+  If the application server allows for fine granularity of observing
+  components, the observer only needs to update its view when
+  the specific components of interest are updated. A potential disadvantage
+  is that the client must register its interest in a number of components.
+</P>
+<P>
+  A disadvantage is that the client may waste time processing notifications
+  when it is not willing to update its view. If notifications are expensive,
+  e.g. when a server has many registered observers, the server may experience
+  unnecessary delays by notifying observers who do not act on the notification.
+</P>
+<H4>Related Patterns</H4>
+<UL>
+  <LI><P>
+    <A href="./pull.html">Pull Domain Model Changes</A>.
+  </P></LI>
+</UL>
+</BODY>
+</HTML>

--- a/style/tx-patterns.css
+++ b/style/tx-patterns.css
@@ -1,0 +1,13 @@
+
+table {
+    width: 100%;
+    border: 1px solid black;
+    border-collapse: collapse;
+}
+th,
+td {
+    border: 1px solid black;
+    padding: 5px;
+    text-align: left;
+    vertical-align: top;
+}


### PR DESCRIPTION
- HTML files are copied as-is from the `resources/tx-patterns` directory to the generated `_site/resources/` during a build.
- I upgraded the HTML from 3.2 to current standards.
